### PR TITLE
Update macOS process name for Brave Browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ export default async function killTabs(options = {}) {
 	const processes = {
 		chrome: process.platform === 'darwin' ? 'Chrome Helper' : 'chrome',
 		chromium: process.platform === 'darwin' ? 'Chromium Helper' : 'chromium',
-		brave: process.platform === 'darwin' ? 'Brave Helper' : 'brave',
+		brave: process.platform === 'darwin' ? 'Brave Browser Helper' : 'brave',
 	};
 
 	if (options.chromium === false) {


### PR DESCRIPTION
Hi @sindresorhus

First, thanks for this module! I use it almost daily both via cli as well as macOS shortcuts to help with memory/battery management.

I noticed that this wasn't killing tabs in Brave Browser. Did a bit of digging and it looks like at some point the process name was updated to 'Brave Browser Helper' on macOS. Unfortunately I don't have access to any other OS at the moment, so wasn't able to check if this issue is also present elsewhere.

Thanks 👋